### PR TITLE
drvoscd: add device match table

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Compile the `drvoscd` driver for [IITE-LINUX-xM][repo_lxm]
 [repo_lxm]: https://github.com/pgils/IITE-LINUX-xM:
 ```
 $ cd linux-stable
+$ git apply ../IITE-DRVO/patches/0001-dts-omap-beagle-xm-map-bmp180-to-I2C2.patch
 $ make ARCH=${CLFS_ARCH} CROSS_COMPILE=${CLFS_TARGET}- \
     INSTALL_MOD_PATH=${CLFS}/targetfs modules_install
 ```

--- a/patches/0001-dts-omap-beagle-xm-map-bmp180-to-I2C2.patch
+++ b/patches/0001-dts-omap-beagle-xm-map-bmp180-to-I2C2.patch
@@ -1,0 +1,28 @@
+From bad8be77249543788d29162b48f5c75b4103b17a Mon Sep 17 00:00:00 2001
+From: Pelle van Gils <pelle@vangils.xyz>
+Date: Mon, 11 May 2020 22:16:21 +0000
+Subject: [PATCH] dts/omap-beagle-xm: map bmp180 to I2C2
+
+---
+ arch/arm/boot/dts/omap3-beagle-xm.dts | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm/boot/dts/omap3-beagle-xm.dts b/arch/arm/boot/dts/omap3-beagle-xm.dts
+index 125ed933ca75..927677ca2087 100644
+--- a/arch/arm/boot/dts/omap3-beagle-xm.dts
++++ b/arch/arm/boot/dts/omap3-beagle-xm.dts
+@@ -302,6 +302,11 @@
+ 
+ &i2c2 {
+ 	clock-frequency = <400000>;
++
++	pressure@77 {
++		compatible = "bosch,bmp180";
++		reg = <0x77>;
++	};
+ };
+ 
+ &i2c3 {
+-- 
+2.20.1
+

--- a/src/drvoscd.c
+++ b/src/drvoscd.c
@@ -10,6 +10,7 @@
 #include <linux/fs.h>
 #include <linux/uaccess.h>
 #include <linux/string.h>
+#include <linux/mod_devicetable.h>
 
 #define DEVICE_NAME "drvoscd"   /* DRiVerOntwikkeling Sensor Character Driver */
 #define CLASS_NAME  "drvo"
@@ -19,6 +20,12 @@
 MODULE_LICENSE("Dual MIT/GPL");
 MODULE_DESCRIPTION("A simple character device driver");
 MODULE_VERSION("0.1");
+
+static const struct of_device_id of_drvoscd_match_tbl[] = {
+    { .compatible = "bosch,bmp180", },
+    { /* end */ }
+};
+MODULE_DEVICE_TABLE(of, of_drvoscd_match_tbl);
 
 static int              majorNumber;
 static struct class*    drvoscdClass = NULL;


### PR DESCRIPTION
add identifier for automatic module loading when probing BMP180 sensor
Also add a patch for the xM dtb to add the sensor on i2c bus